### PR TITLE
fix dist folder to version + cordova

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actyx-contrib/axp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Actyx Project CLI tool to create and maintain your TypeScript based projects",
   "bin": {
     "axp": "bin/axp"

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -166,6 +166,8 @@ const addUI = async (command: Command): Promise<void> => {
     packageJson.scripts = {
       ...packageJson.scripts,
       [`ui:${appName}:package`]: `ax apps package src/${appName}/ax-manifest.yml`,
+      // fix bug in `ax apps package`
+      // build to src/${appName}/release to make ax apps package working
       [`ui:${appName}:build`]: `parcel build src/${appName}/index.html --out-dir src/${appName}/release --public-url ./`,
     }
   } else {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -161,12 +161,18 @@ const addUI = async (command: Command): Promise<void> => {
   packageJson.scripts = {
     ...packageJson.scripts,
     [`ui:${appName}:start`]: `parcel src/${appName}/index.html --out-dir build/${appName}/debug`,
-    [`ui:${appName}:build`]: `parcel build src/${appName}/index.html --out-dir src/${appName}/release --public-url ./`,
   }
   if (createRuntimeSupport(pondVersion)) {
     packageJson.scripts = {
       ...packageJson.scripts,
       [`ui:${appName}:package`]: `ax apps package src/${appName}/ax-manifest.yml`,
+      [`ui:${appName}:build`]: `parcel build src/${appName}/index.html --out-dir src/${appName}/release --public-url ./`,
+    }
+  } else {
+    packageJson.scripts = {
+      ...packageJson.scripts,
+      [`ui:${appName}:package`]: `ax apps package src/${appName}/ax-manifest.yml`,
+      [`ui:${appName}:build`]: `parcel build src/${appName}/index.html --out-dir build/${appName}/release --public-url ./`,
     }
   }
   if (createAppManifest(pondVersion)) {

--- a/src/commands/addFeature.ts
+++ b/src/commands/addFeature.ts
@@ -186,6 +186,7 @@ const addCordova = async (appName: string, projectPath: string): Promise<void> =
     )
     return
   }
+  const pondVersion = getPondVersion()
 
   const createExampleDone = createSpinner('Setup cordova template')
 
@@ -199,7 +200,7 @@ const addCordova = async (appName: string, projectPath: string): Promise<void> =
     writeFileInPathSyncIfNotExists(
       `${cordovaDir}/scripts`,
       'buildApp.js',
-      cordovaBuildScripts(appName),
+      cordovaBuildScripts(appName, pondVersion),
     )
     writeFileInPathSyncIfNotExists(`${cordovaDir}/www`, 'gitkeep', '')
   }

--- a/src/templates/ui/cordova.ts
+++ b/src/templates/ui/cordova.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createRuntimeSupport, PondVersions } from '../../utils'
+
 export const cordovaPackageJson = (appName: string): string => `{
   "name": "${appName}",
   "displayName": "${appName}",
@@ -39,7 +41,7 @@ export const cordovaPackageJson = (appName: string): string => `{
 `
 
 export const cordovaConfigXml = (appName: string): string => `<?xml version='1.0' encoding='utf-8'?>
-<widget id="${appName}" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.example.change.me.${appName}" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>${appName}</name>
     <description>
         TODO
@@ -79,9 +81,11 @@ node_modules/
 !/www/gitkeep
 `
 
-export const cordovaBuildScripts = (
-  appName: string,
-): string => `/* eslint-disable @typescript-eslint/no-var-requires */
+export const cordovaBuildScripts = (appName: string, pondVersion: PondVersions): string => {
+  const distPath = createRuntimeSupport(pondVersion)
+    ? `src/\${appName}/release`
+    : `build/\${appName}/release`
+  return `/* eslint-disable @typescript-eslint/no-var-requires */
 'use strict'
 const appName = '${appName}'
 
@@ -92,7 +96,7 @@ const { execSync } = require('child_process')
 
 var dir = resolve(__dirname, '..')
 var projectMain = resolve(dir, '../../..')
-var htmlSource = join(projectMain, \`src/\${appName}/release\`)
+var htmlSource = join(projectMain, \`${distPath}\`)
 var outputDir = join(dir, 'www')
 
 const main = () => {
@@ -121,3 +125,4 @@ const main = () => {
 }
 main()
 `
+}

--- a/src/templates/ui/index.ts
+++ b/src/templates/ui/index.ts
@@ -166,11 +166,11 @@ export const App = (): JSX.Element => {
           </a>
         </li>
         <li>
-          <a href="https://developer.actyx.com/docs/pond/getting-started">Pond - getting-started</a>
+          <a href="https://developer.actyx.com/docs/how-to/overview">Actyx - how-to</a>
         </li>
         <li>
-          <a href="https://developer.actyx.com/docs/pond/guides/hello-world">
-            Guides - hello-world
+          <a href="https://developer.actyx.com/docs/how-to/actyx-pond/introduction">
+            Introduction to Actyx Pond
           </a>
         </li>
       </ul>


### PR DESCRIPTION
# cleanup 

the old "build to src" is no longer required.

It was required to work around an ax-manifest bug